### PR TITLE
Renamed struct from MinerWorker to MinerPoolWorker

### DIFF
--- a/minerpoolworker/loop.go
+++ b/minerpoolworker/loop.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func (p *MinerWorker) loop() {
+func (p *MinerPoolWorker) loop() {
 
 	sendPingMsgToPoolServer := time.NewTicker(time.Second * 55)
 	checkPongMsgReturn := time.NewTicker(time.Second * 10)


### PR DESCRIPTION
There was a name conflict between package minerworker and package minerpoolworker
Both were using a struct named MinerWorker, posing a naming conflict

The struct for package minerpoolworker was renamed to MinerPoolWorker