### PR TITLE
Renamed struct from MinerWorker to MinerPoolWorker

### DIFF
--- a/minerpoolworker/power.go
+++ b/minerpoolworker/power.go
@@ -5,7 +5,7 @@ import (
 	"math/big"
 )
 
-func (p *MinerWorker) addPowerLogReturnShow(hxworth *big.Int) string {
+func (p *MinerPoolWorker) addPowerLogReturnShow(hxworth *big.Int) string {
 
 	p.powerTotalCmx.Add(hxworth)
 	if p.powerTotalCmx.Cardinality() > 24 {


### PR DESCRIPTION
There was a name conflict between package minerworker and package minerpoolworker
Both were using a struct named MinerWorker, posing a naming conflict

The struct for package minerpoolworker was renamed to MinerPoolWorker