### PR TITLE
Renamed struct from MinerWorker to MinerPoolWorker

### DIFF
--- a/minerpoolworker/connect.go
+++ b/minerpoolworker/connect.go
@@ -15,7 +15,7 @@ const (
 	MsgMarkPong             = "pong"
 )
 
-func (p *MinerWorker) startConnect() error {
+func (p *MinerPoolWorker) startConnect() error {
 
 	p.isInConnecting = true
 
@@ -31,7 +31,7 @@ func (p *MinerWorker) startConnect() error {
 
 }
 
-func (p *MinerWorker) handleConn(conn *net.TCPConn) {
+func (p *MinerPoolWorker) handleConn(conn *net.TCPConn) {
 
 	fmt.Print("connecting miner pool... ")
 


### PR DESCRIPTION
There was a name conflict between package minerworker and package minerpoolworker
Both were using a struct named MinerWorker, posing a naming conflict

The struct for package minerpoolworker was renamed to MinerPoolWorker